### PR TITLE
Corrected captcha names in the Portuguese version: Cloudflare Challenge | AWS WAF Challenge

### DIFF
--- a/i18n/pt-br/docusaurus-plugin-content-docs/current/captchas/amazon-task.mdx
+++ b/i18n/pt-br/docusaurus-plugin-content-docs/current/captchas/amazon-task.mdx
@@ -14,13 +14,13 @@ import PriceBlock from '@theme/PriceBlock';
 import PriceBlockWrap from '@theme/PriceBlockWrap';
 import BlogLink from '@theme/BlogLink';
 
-# AmazonTask | AWS WAF Captcha e Desafio
+# AmazonTask | AWS WAF Captcha e Challenge
 
 <PriceBlockWrap>
   <PriceBlock title="AmazonTask" name="amazonToken"/>
 </PriceBlockWrap>
 
-Resolvendo CAPTCHA e desafio no AWS WAF
+Resolvendo CAPTCHA e Challenge no AWS WAF
 
 <BlogLink url="https://capmonster.cloud/pt-BR/blog/scraping/amazon-captcha-web-scraping"/>
 
@@ -79,7 +79,7 @@ Link para o challenge.js (veja a descrição abaixo)
 ---
 
     <ParamItem title="captchaScript" type="string" />
-    Link para captcha.js (talvez esteja faltando se você tiver apenas um desafio)
+    Link para captcha.js (talvez esteja faltando se você tiver apenas um challenge)
 
 ---
 

--- a/i18n/pt-br/docusaurus-plugin-content-docs/current/captchas/turnstile-task.mdx
+++ b/i18n/pt-br/docusaurus-plugin-content-docs/current/captchas/turnstile-task.mdx
@@ -12,7 +12,7 @@ import PriceBlock from '@theme/PriceBlock';
 import PriceBlockWrap from '@theme/PriceBlockWrap';
 import BlogLink from '@theme/BlogLink';
 
-# TurnstileTask | Desafio Cloudflare
+# TurnstileTask | Cloudflare Challenge
 
 <PriceBlockWrap>
   <PriceBlock title="TurnstileTask" name="turnstileToken"/>
@@ -27,7 +27,7 @@ Todos os subtipos do Turnstile são suportados automaticamente: manual, não int
 Confira todas as três opções de reconhecimento de captcha e escolha a mais conveniente para você.
 :::
 ## Opção 1 (Turnstile)
-Você precisa resolver um captcha comum do turnstile, como mostrado aqui. Observe que o CAPTCHA em páginas da CloudFlare pode parecer idêntico. Saiba mais sobre como diferenciar um Turnstile comum de um Desafio Cloudflare no final do artigo.
+Você precisa resolver um captcha comum do turnstile, como mostrado aqui. Observe que o CAPTCHA em páginas da CloudFlare pode parecer idêntico. Saiba mais sobre como diferenciar um Turnstile comum de um Cloudflare Challenge no final do artigo.
 
 #### Parâmetros da solicitação
 <TabItem value="proxyless" label="RecaptchaV2EnterpriseTaskProxyless (sem proxy)" default className="bordered-panel">
@@ -326,7 +326,7 @@ Use o método [getTaskResult](../api/methods/get-task-result.md) para obter a so
 |cf_clearance|String|Um cookie especial da Cloudflare que você pode substituir no seu navegador|
 |token|String|Use o token ao chamar uma função de callback|
 
-## Como diferenciar entre um Turnstile comum e um Desafio Cloudflare
+## Como diferenciar entre um Turnstile comum e um Cloudflare Challenge
 Um desafio da Cloudflare pode ter uma aparência diferente.
 
 **Variante normal:**


### PR DESCRIPTION
Исправлены названия капч в португальской версии: Cloudflare Challenge | AWS WAF Challenge